### PR TITLE
Interim compatibility code

### DIFF
--- a/music.py
+++ b/music.py
@@ -1,5 +1,11 @@
-from errbot.botplugin import BotPlugin
-from errbot.jabberbot import botcmd
+# Backward compatibility
+from errbot.version import VERSION
+from errbot.utils import version2array
+if version2array(VERSION) >= [1,6,0]:
+    from errbot import botcmd, BotPlugin
+else:
+    from errbot.botplugin import BotPlugin
+    from errbot.jabberbot import botcmd
 
 from BeautifulSoup import BeautifulSoup
 import urllib


### PR DESCRIPTION
Once you are ready to put your plugin 1.6.0+ only, just change this horrible blurb to :
from errbot import botcmd, BotPlugin
